### PR TITLE
Allow Jenkins to access Docker (Resolves #9)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,8 +77,8 @@ Vagrant.configure("2") do |config|
     #ansible.tags = ["common"]
     #ansible.tags = ["selinux", "accounts", "firewall"]
     #ansible.tags = ["base-packages", "extra-packages"]
-    #ansible.tags = ["docker"]
     #ansible.tags = ["nodejs"]
+    #ansible.tags = ["jenkins"]
     #ansible.verbose = "v"
   end
 

--- a/jenkins-server.yml
+++ b/jenkins-server.yml
@@ -4,7 +4,6 @@
   become: true
   roles:
     - common
-    - docker
     - nodejs
     - jenkins
 

--- a/roles/jenkins/meta/main.yml
+++ b/roles/jenkins/meta/main.yml
@@ -14,4 +14,6 @@ galaxy_info:
   galaxy_tags:
     - jenkins
 
-dependencies: []
+dependencies:
+  - docker
+

--- a/roles/jenkins/tasks/configuration.yml
+++ b/roles/jenkins/tasks/configuration.yml
@@ -2,7 +2,6 @@
 
 - name: add 'jenkins' user to 'docker' group
   user: name=jenkins groups=docker append=yes
-  tags: docker
 
 - name: jenkins running and enabled
   service: name=jenkins state=started enabled=yes

--- a/roles/jenkins/tasks/configuration.yml
+++ b/roles/jenkins/tasks/configuration.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: add 'jenkins' user to 'docker' group
+  user: name=jenkins groups=docker append=yes
+  tags: docker
+
 - name: jenkins running and enabled
   service: name=jenkins state=started enabled=yes
 


### PR DESCRIPTION
Proof that it solves issue #9, as per https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user instructions:

![screen shot 2017-08-25 at 11 57 03 am](https://user-images.githubusercontent.com/786326/29709568-19281950-898d-11e7-8f26-e88becdaa06d.png)

@vtepliuk Call me if you're having trouble understanding what commit 3d32ca2 does and why!
