### PR TITLE
If available, use `extra_volumes` for JENKINS_HOME (fixes #12)

### DIFF
--- a/roles/jenkins/tasks/installation.yml
+++ b/roles/jenkins/tasks/installation.yml
@@ -13,4 +13,23 @@
 - name: install jenkins-2.60-1.1
   yum: name=jenkins-2.60-1.1 state=present
 
+- block:
+    - name: create /mnt/lvm/jenkins home dir
+      file:
+        path: /mnt/lvm/jenkins
+        owner: jenkins
+        group: jenkins
+        state: directory
+
+    - name: mount /mnt/lvm/jenkins as /var/lib/jenkins
+      mount:
+        name: /var/lib/jenkins
+        src: /mnt/lvm/jenkins
+        fstype: none
+        opts: bind
+        state: mounted
+        boot: no
+
+  when: extra_volumes
+
 ...


### PR DESCRIPTION
Use `extra_volumes` LVM partition `/mnt/lvm` as bind-mounted JENKINS_HOME.

Proof that it works:

```
[mblomdahl@jenkins ~]$ mount -l
sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime,seclabel)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=1921992k,nr_inodes=480498,mode=755)
securityfs on /sys/kernel/security type securityfs (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,seclabel)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,seclabel,gid=5,mode=620,ptmxmode=000)
tmpfs on /run type tmpfs (rw,nosuid,nodev,seclabel,mode=755)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,seclabel,mode=755)
cgroup on /sys/fs/cgroup/systemd type cgroup (rw,nosuid,nodev,noexec,relatime,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd)
pstore on /sys/fs/pstore type pstore (rw,nosuid,nodev,noexec,relatime)
cgroup on /sys/fs/cgroup/blkio type cgroup (rw,nosuid,nodev,noexec,relatime,blkio)
cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (rw,nosuid,nodev,noexec,relatime,cpuacct,cpu)
cgroup on /sys/fs/cgroup/net_cls type cgroup (rw,nosuid,nodev,noexec,relatime,net_cls)
cgroup on /sys/fs/cgroup/hugetlb type cgroup (rw,nosuid,nodev,noexec,relatime,hugetlb)
cgroup on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)
cgroup on /sys/fs/cgroup/freezer type cgroup (rw,nosuid,nodev,noexec,relatime,freezer)
cgroup on /sys/fs/cgroup/perf_event type cgroup (rw,nosuid,nodev,noexec,relatime,perf_event)
cgroup on /sys/fs/cgroup/devices type cgroup (rw,nosuid,nodev,noexec,relatime,devices)
configfs on /sys/kernel/config type configfs (rw,relatime)
/dev/xvda1 on / type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
rpc_pipefs on /var/lib/nfs/rpc_pipefs type rpc_pipefs (rw,relatime)
selinuxfs on /sys/fs/selinux type selinuxfs (rw,relatime)
systemd-1 on /proc/sys/fs/binfmt_misc type autofs (rw,relatime,fd=25,pgrp=1,timeout=300,minproto=5,maxproto=5,direct)
mqueue on /dev/mqueue type mqueue (rw,relatime,seclabel)
hugetlbfs on /dev/hugepages type hugetlbfs (rw,relatime,seclabel)
debugfs on /sys/kernel/debug type debugfs (rw,relatime)
nfsd on /proc/fs/nfsd type nfsd (rw,relatime)
/dev/mapper/extra_volumes-lvm on /mnt/lvm type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/xvda1 on /var/lib/docker/plugins type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/xvda1 on /var/lib/docker/overlay type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
/dev/mapper/extra_volumes-lvm on /var/lib/jenkins type xfs (rw,relatime,seclabel,attr2,inode64,noquota)
tmpfs on /run/user/1002 type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=361904k,mode=700,uid=1002,gid=1003)
[mblomdahl@jenkins ~]$ 
```
