### PR TITLE
Add python role for libris/xl_auth#7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,6 +78,7 @@ Vagrant.configure("2") do |config|
     #ansible.tags = ["selinux", "accounts", "firewall"]
     #ansible.tags = ["base-packages", "extra-packages"]
     #ansible.tags = ["nodejs"]
+    #ansible.tags = ["python"]
     #ansible.tags = ["jenkins"]
     #ansible.verbose = "v"
   end

--- a/jenkins-server.yml
+++ b/jenkins-server.yml
@@ -5,6 +5,7 @@
   roles:
     - common
     - nodejs
+    - python
     - jenkins
 
 ...

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: Mats Blomdahl
+  description: Provisioning of SCL, VirtualEnv and Python 2/3.
+
+  license: MIT
+
+  min_ansible_version: 2.2
+
+  platforms:
+    - name: EL
+      versions:
+        - 7
+
+  galaxy_tags:
+    - python
+    - scl
+    - virtualenv
+
+dependencies: []

--- a/roles/python/tasks/installation.yml
+++ b/roles/python/tasks/installation.yml
@@ -1,0 +1,38 @@
+---
+
+- name: install python-virtualenv
+  yum: name=python-virtualenv state=present
+
+- name: install virtualenv-15.1.0
+  pip: name=virtualenv version=15.1.0 state=present
+
+- name: install centos-release-scl
+  yum: name=centos-release-scl state=present
+
+- name: install python27
+  yum: name=python27 state=present
+
+- name: install scl python27 pip-9.0.1
+  shell: scl enable python27 "pip install pip==9.0.1"
+  register: scl_python27_pip_install
+  changed_when: scl_python27_pip_install.stdout.find('already satisfied') == -1
+
+- name: install scl python27 virtualenv-15.1.0
+  shell: scl enable python27 "pip install virtualenv==15.1.0"
+  register: scl_python27_virtualenv_install
+  changed_when: scl_python27_virtualenv_install.stdout.find('already satisfied') == -1
+
+- name: install rh-python35
+  yum: name=rh-python35 state=present
+
+- name: install scl rh-python35 pip-9.0.1
+  shell: scl enable rh-python35 "pip install pip==9.0.1"
+  register: scl_rh_python35_pip_install
+  changed_when: scl_rh_python35_pip_install.stdout.find('already satisfied') == -1
+
+- name: install scl rh-python35 virtualenv-15.1.0
+  shell: scl enable rh-python35 "pip install virtualenv==15.1.0"
+  register: scl_rh_python35_virtualenv_install
+  changed_when: scl_rh_python35_virtualenv_install.stdout.find('already satisfied') == -1
+
+...

--- a/roles/python/tasks/main.yml
+++ b/roles/python/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: install scl, python27 and python35 and virtualenv
+  include: installation.yml
+  tags: python
+
+...


### PR DESCRIPTION
Add `python` role for installing python27/rh-python35, virtualenv and other requirements to test libris/xl_auth#7 CI integration.
